### PR TITLE
Use prop-types instead of flow

### DIFF
--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -47,12 +47,11 @@
     "babel-preset-env": "latest",
     "babel-preset-react": "latest",
     "babel-preset-react-optimize": "latest",
-    "eslint-plugin-flowtype": "latest",
     "eslint-plugin-jsx-a11y": "latest",
-    "flow-bin": "latest",
     "husky": "latest",
     "lint-staged": "latest",
     "prettier-standard": "latest",
+    "prop-types": "latest",
     "size-limit": "latest",
     "standard": "latest",
     "standard-markdown": "latest",
@@ -68,7 +67,6 @@
     "build": "NODE_ENV=production BABEL_ENV=production babel src -d lib",
     "build-storybook": "build-storybook",
     "dev": "start-storybook -p 6006",
-    "flow": "flow",
     "lint": "standard-markdown && standard src stories",
     "posttest": "npm run size",
     "pretest": "npm run lint",
@@ -80,7 +78,6 @@
   "license": "MIT",
   "lint-staged": {
     "*.js": [
-      "flow",
       "prettier-standard",
       "git add"
     ]
@@ -98,7 +95,6 @@
     ],
     "parser": "babel-eslint",
     "plugins": [
-      "flowtype",
       "jsx-a11y"
     ]
   }

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -1,18 +1,8 @@
-// @flow
 import React from 'react'
 import styled from 'styled-components'
 import extractDomain from 'extract-domain'
 
-import type { CardSizes } from './index'
 import { CardContentLarge } from './CardLarge'
-
-type ContentProps = {
-  cardSize?: CardSizes,
-  title?: string,
-  description?: string,
-  url?: string,
-  className?: string
-}
 
 export const Content = styled.div`
   flex: 1;
@@ -51,7 +41,7 @@ const Url = styled.span`
   display: inline-block;
 `
 
-export default ({ title, description, url, cardSize, className }: ContentProps) => (
+export default ({ title, description, url, cardSize, className }) => (
   <Content className={className} cardSize={cardSize}>
     <Title className='microlink_card__content_title' title={title}>{title}</Title>
     <Description className='microlink_card__content_description'>{description}</Description>

--- a/packages/react-microlink/src/components/Card/CardEmptyState.js
+++ b/packages/react-microlink/src/components/Card/CardEmptyState.js
@@ -1,15 +1,9 @@
-// @flow
 import React, { Fragment } from 'react'
 import styled from 'styled-components'
 
-import type { CardSizes } from './index'
 import CardImage from './CardImage'
 import { Content } from './CardContent'
 import { emptyStateAnimation, emptyStateImageAnimation } from './CardAnimations'
-
-type EmptyStateProps = {
-  cardSize?: CardSizes
-}
 
 const EmptyImage = CardImage.extend`
   ${emptyStateImageAnimation}
@@ -64,7 +58,7 @@ const EmptyLink = styled.span`
   animation-delay: .25s;
 `
 
-const CardEmptyState = ({cardSize}: EmptyStateProps) => (
+const CardEmptyState = ({cardSize}) => (
   <Fragment>
     <EmptyImage cardSize={cardSize} />
     <Content cardSize={cardSize}>

--- a/packages/react-microlink/src/index.js
+++ b/packages/react-microlink/src/index.js
@@ -1,43 +1,10 @@
-// @flow
 import React, { Fragment, Component } from 'react'
-import type { Key } from 'react'
+import PropTypes from 'prop-types'
 
 import { CardWrap, CardImage, CardContent, CardEmptyState } from './components/Card'
 import { getUrlPath } from './utils'
 
-export type CardSizes = 'large' | 'small'
-
-type CardProps = {
-  className?: string,
-  contrast?: boolean,
-  endpoint: string,
-  is?: any,
-  key?: Key,
-  rel?: string,
-  rounded?: boolean | string,
-  size?: CardSizes,
-  style?: {[string]: mixed},
-  target?: string,
-  url: string
-}
-
-type State = {
-  backgroundColor?: string,
-  color?: string,
-  description?: string,
-  image?: string,
-  loading: boolean,
-  title?: string,
-  url?: string
-}
-
-export default class extends Component<CardProps, State> {
-  static defaultProps = {
-    endpoint: 'https://api.microlink.io'
-  }
-
-  state: State = { loading: true }
-
+class Microlink extends Component {
   componentWillMount () {
     const { url: targetUrl, contrast, endpoint: api } = this.props
 
@@ -48,27 +15,18 @@ export default class extends Component<CardProps, State> {
       this.setState({ loading: true }, () =>
         fetch(url)
           .then(res => res.json())
-          .then((res: Object) => {
-            const {status = '', data}: {status: string, data: Object} = res
-            if (status === 'success') {
-              const { title, description, url, image }: {
-                title?: string,
-                description?: string,
-                url?: string,
-                image?: string | Object
-              } = data
-
-              if (image) {
-                if (typeof image === 'object') {
-                  const {color, background_color: backgroundColor}: {color: string, background_color: string} = image
-                  this.setState({color, backgroundColor})
-                }
-                const imagePath = getUrlPath(image)
-                this.setState({image: imagePath})
-              }
-
-              this.setState({ title, description, url, loading: false })
-            }
+          .then(({status, data}) => {
+            const { title, description, url, image } = data
+            const {color, background_color: backgroundColor} = image
+            this.setState({
+              color,
+              backgroundColor,
+              title,
+              description,
+              url,
+              loading: false,
+              image: getUrlPath(image)
+            })
           })
       )
     }
@@ -102,7 +60,7 @@ export default class extends Component<CardProps, State> {
 
     return (
       <CardWrap
-        className={className ? `microlink_card ${className}` : className}
+        className={className ? `microlink_card ${className}` : 'microlink_card'}
         href={url}
         title={title}
         cardSize={size}
@@ -116,3 +74,20 @@ export default class extends Component<CardProps, State> {
     )
   }
 }
+
+Microlink.defaultProps = {
+  endpoint: 'https://api.microlink.io',
+  size: 'normal'
+}
+
+Microlink.propTypes = {
+  url: PropTypes.string.isRequired,
+  size: PropTypes.string,
+  endpoint: PropTypes.string,
+  contrast: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool
+  ])
+}
+
+export default Microlink

--- a/packages/react-microlink/src/utils/index.js
+++ b/packages/react-microlink/src/utils/index.js
@@ -1,3 +1,1 @@
-// @flow
-export const getUrlPath = (data: {url: string} | string): string =>
-  typeof data === 'object' ? data.url : data
+export const getUrlPath = data => typeof data === 'object' ? data.url : data

--- a/packages/react-microlink/stories/index.js
+++ b/packages/react-microlink/stories/index.js
@@ -1,5 +1,3 @@
-// @flow
-
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import 'unfetch/polyfill'


### PR DESCRIPTION
- A lot of definitions around the code. 
- The library is too simple for the flow user case.
- Added `prop-types` as dev dependency.
- prettier-standard is not working well with flow and babel language extension.
- Fixed a bug related with `microlink__card` class.