### PR TITLE
UMD: Add support for inline data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ document.addEventListener('DOMContentLoaded', function (event) {
 })
 ```
 
+Also, you can declare inline options in the HTML markup as `data` attributes:
+
+```html
+<a class="link" data-rounded="true" href="http://microlink.js.org">microlink.js.org</a>
+```
+
 ## API
 
 We even provided different ways to integrate microlink with your site and your code, our API is isomorphic.

--- a/packages/microlinkjs/public/index.html
+++ b/packages/microlinkjs/public/index.html
@@ -27,12 +27,12 @@
     <p>was created. You should try it today to make your own motherfucking websites.</p></p>
 
     <p>From the philosophies expressed (poorly) above</p>
-    <a class="link" href="http://txti.es">txti</a>
+    <a class="link" data-contrast="true" href="http://txti.es">txti</a>
     <p>was created. You should try it today to make your own motherfucking websites.</p></p>
   </body>
   <script>
     document.addEventListener("DOMContentLoaded", function(event) {
-      microlink('.link', {rounded: true, contrast:true});
+      microlink('.link', {rounded: true});
     });
   </script>
 </html>

--- a/packages/microlinkjs/src/index.js
+++ b/packages/microlinkjs/src/index.js
@@ -7,10 +7,21 @@ const React = require('react')
 
 const {default: MicrolinkCard} = require('react-microlink')
 
+const BOOLEAN_STRINGS = ['true', 'false']
+
+const getBoolean = str => str === 'true'
+const isStringBoolean = str => BOOLEAN_STRINGS.includes(str)
+
+const getDataAttributes = el => Object.keys(el.dataset).reduce((acc, key) => {
+  const value = el.dataset[key]
+  acc[key] = isStringBoolean(value) ? getBoolean(value) : value
+  return acc
+}, {})
+
 module.exports = (selector, {is = 'div', ...opts} = {}) => (
   each(qa(selector), el => {
     const url = el.getAttribute('href')
-    const params = { url, is, ...opts }
+    const params = { url, is, ...opts, ...getDataAttributes(el) }
     const card = React.createElement(MicrolinkCard, params)
     ReactDOM.render(card, el)
   })


### PR DESCRIPTION
I found a clean way to do that using [dataset](https://caniuse.com/#search=dataset), and looks with enough compatibility.

Closes https://github.com/microlinkhq/microlinkjs/issues/39