### PR TITLE
Improve responsive

### DIFF
--- a/packages/react-microlink/.storybook/addons.js
+++ b/packages/react-microlink/.storybook/addons.js
@@ -3,3 +3,4 @@
 import '@storybook/addon-actions/register'
 import '@storybook/addon-links/register'
 import '@storybook/addon-options/register'
+import '@storybook/addon-viewport/register'

--- a/packages/react-microlink/.storybook/config.js
+++ b/packages/react-microlink/.storybook/config.js
@@ -1,12 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
 import { configure } from '@storybook/react'
-import { setOptions } from '@storybook/addon-options'
 
 function loadStories () {
   require('../stories')
 }
-
-setOptions({ showDownPanel: false })
 
 configure(loadStories, module)

--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@storybook/addon-options": "latest",
+    "@storybook/addon-viewport": "~3.3.8",
     "@storybook/react": "latest",
     "babel-cli": "latest",
     "babel-eslint": "latest",

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -34,7 +34,7 @@ const Description = styled.p`
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 
-  ${media.mobile`
+  ${({cardSize}) => cardSize !== 'large' && media.mobile`
     white-space: nowrap;
   `}
 
@@ -52,7 +52,10 @@ const Url = styled.span`
 export default ({ title, description, url, cardSize, className }) => (
   <Content className={className} cardSize={cardSize}>
     <Title className='microlink_card__content_title' title={title}>{title}</Title>
-    <Description className='microlink_card__content_description'>{description}</Description>
+    <Description
+      className='microlink_card__content_description'
+      cardSize={cardSize}
+    >{description}</Description>
     <Url className='microlink_card__content_url'>{extractDomain(url)}</Url>
   </Content>
 )

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import extractDomain from 'extract-domain'
 
 import { CardContentLarge } from './CardLarge'
+import { media } from '../../utils'
 
 export const Content = styled.div`
   flex: 1;
@@ -15,28 +16,35 @@ export const Content = styled.div`
 const Title = styled.h2`
   font-size: 16px;
   margin: 0 0 8px;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  overflow: hidden;
   max-width: 95%;
+
+  ${media.mobile`
+    white-space: nowrap;
+  `}
 `
 
 const Description = styled.p`
   font-size: 14px;
   margin: 0;
   line-height: 18px;
-  height: 54px;
-  overflow: hidden;
   text-overflow: ellipsis;
+  overflow: hidden;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+
+  ${media.mobile`
+    white-space: nowrap;
+  `}
+
+  ${media.desktop`
+    height: 54px;
+  `}
 `
 
 const Url = styled.span`
   font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   margin-top: 10px;
   display: inline-block;
 `

--- a/packages/react-microlink/src/components/Card/CardEmptyState.js
+++ b/packages/react-microlink/src/components/Card/CardEmptyState.js
@@ -1,9 +1,10 @@
 import React, { Fragment } from 'react'
 import styled from 'styled-components'
 
-import CardImage from './CardImage'
-import { Content } from './CardContent'
 import { emptyStateAnimation, emptyStateImageAnimation } from './CardAnimations'
+import { Content } from './CardContent'
+import CardImage from './CardImage'
+import { media } from '../../utils'
 
 const EmptyImage = CardImage.extend`
   ${emptyStateImageAnimation}
@@ -20,7 +21,6 @@ const EmptyTitle = styled.span`
 `
 
 const EmptyDescription = styled.span`
-  height: 54px;
   width: 100%;
   display: block;
   background: #e1e8ed;
@@ -30,14 +30,22 @@ const EmptyDescription = styled.span`
   ${emptyStateAnimation}
   animation-delay: .125s;
 
-  &:before, &:after {
-    content: '';
-    position: absolute;
-    left: -1px;
-    right: -1px;
-    height: 6px;
-    background: #fff;
-  }
+  ${({cardSize}) => cardSize !== 'large' && media.mobile`
+    height: 14px;
+  `}
+
+  ${({cardSize}) => cardSize !== 'large' && media.desktop`
+    height: 54px;
+
+    &:before, &:after {
+      content: '';
+      position: absolute;
+      left: -1px;
+      right: -1px;
+      height: 6px;
+      background: #fff;
+    }
+  `}
 
   &:before {
     top: 14px;
@@ -58,15 +66,18 @@ const EmptyLink = styled.span`
   animation-delay: .25s;
 `
 
-const CardEmptyState = ({cardSize}) => (
-  <Fragment>
-    <EmptyImage cardSize={cardSize} />
-    <Content cardSize={cardSize}>
-      <EmptyTitle />
-      <EmptyDescription />
-      <EmptyLink />
-    </Content>
-  </Fragment>
-)
+const CardEmptyState = ({cardSize}) => {
+  console.log('cardSize', cardSize)
+  return (
+    <Fragment>
+      <EmptyImage cardSize={cardSize} />
+      <Content cardSize={cardSize}>
+        <EmptyTitle />
+        <EmptyDescription cardSize={cardSize} />
+        <EmptyLink />
+      </Content>
+    </Fragment>
+  )
+}
 
 export default CardEmptyState

--- a/packages/react-microlink/src/components/Card/CardImage.js
+++ b/packages/react-microlink/src/components/Card/CardImage.js
@@ -1,10 +1,16 @@
 import styled from 'styled-components'
+
 import { CardImageLarge } from './CardLarge'
+import { media } from '../../utils'
 
 export default styled.div`
   display: block;
   flex: 0 0 125px;
   background: #e1e8ed no-repeat center center / cover;
+
+  ${media.mobile`
+    flex: 0 0 92px;
+  `}
 
   &::before {
     content: '';

--- a/packages/react-microlink/src/components/Card/CardImage.js
+++ b/packages/react-microlink/src/components/Card/CardImage.js
@@ -8,10 +8,6 @@ export default styled.div`
   flex: 0 0 125px;
   background: #e1e8ed no-repeat center center / cover;
 
-  ${media.mobile`
-    flex: 0 0 92px;
-  `}
-
   &::before {
     content: '';
     padding-bottom: 100%;
@@ -19,5 +15,10 @@ export default styled.div`
   }
 
   ${({image}) => image && `background-image: url(${image});`}
+
   ${({cardSize}) => cardSize === 'large' && CardImageLarge}
+
+  ${({cardSize}) => cardSize !== 'large' && media.mobile`
+    flex: 0 0 92px;
+  `}
 `

--- a/packages/react-microlink/src/components/Card/CardLarge.js
+++ b/packages/react-microlink/src/components/Card/CardLarge.js
@@ -1,8 +1,15 @@
 import { css } from 'styled-components'
+import { media } from '../../utils'
+
+const HEIGHT = '382px'
 
 export const CardWrapLarge = css`
   flex-direction: column;
-  height: 382px;
+  height: ${HEIGHT};
+
+  ${media.mobile`
+    height: calc(${HEIGHT} * 7/9);
+  `}
 `
 
 export const CardContentLarge = css`

--- a/packages/react-microlink/src/components/Card/CardWrap.js
+++ b/packages/react-microlink/src/components/Card/CardWrap.js
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components'
 import { CardWrapLarge } from './CardLarge'
 
 const style = css`
-  width: 558px;
+  max-width: 558px;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   background-color: #fff;
   color: #181919;

--- a/packages/react-microlink/src/utils/index.js
+++ b/packages/react-microlink/src/utils/index.js
@@ -1,6 +1,26 @@
+import { css, style } from 'styled-components'
+
 export const getUrlPath = data => typeof data === 'object' ? data.url : data
 
 export const uniqArray = array => Array.from(new Set(array))
 
 export const someProp = (data, props) =>
   data[props.find(prop => data[prop] !== null && data[prop] !== undefined)]
+
+export const media = {
+  mobile: (...args) => css`
+    @media (max-width: 48em) {
+      ${css(...args)}
+    }
+  `,
+  desktop: (...args) => css`
+    @media (min-width: 48em) {
+      ${css(...args)}
+    }
+  `
+}
+
+export const ellipsis = `
+  text-overflow: ellipsis;
+  overflow: hidden;
+`


### PR DESCRIPTION
Fix #37

I added responsive (mobile) style for normal and large card.

![screen shot 2018-01-12 at 17 24 28](https://user-images.githubusercontent.com/2096101/34884611-8a60fd00-f7bd-11e7-9e90-de219b20e629.png)

Also I added viewport storybook for be possible visualize it 😄

The only TODO before merge it is how to convert the three lines empty state into one under mobile viewport. any idea, @breadadams?

![screen_shot_2018-01-12_at_17_24_22](https://user-images.githubusercontent.com/2096101/34884627-93cf9298-f7bd-11e7-8969-97e9d219fcdb.png)