### PR TITLE
Add three lines clamp cross browser

### DIFF
--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "extract-domain": "~2.0.0",
     "prop-types": "~15.6.0",
+    "react-clamp-lines": "~1.0.2",
     "styled-components": "~2.4.0"
   },
   "devDependencies": {

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -1,62 +1,73 @@
 import React from 'react'
 import styled from 'styled-components'
 import extractDomain from 'extract-domain'
+import ClampLines from 'react-clamp-lines'
 
-import { CardContentLarge } from './CardLarge'
-import { media } from '../../utils'
+import {CardContentLarge} from './CardLarge'
+import {media} from '../../utils'
 
 export const Content = styled.div`
+  display: flex;
+  justify-content: space-around;
+  flex-direction: column;
   flex: 1;
   padding: 10px 15px;
   min-width: 0;
   box-sizing: border-box;
-  ${({cardSize}) => cardSize === 'large' && CardContentLarge}
+  ${({cardSize}) => cardSize === 'large' && CardContentLarge};
 `
 
-const Title = styled.h2`
+const Title = styled.p`
   font-size: 16px;
-  margin: 0 0 8px;
+  font-weight: bold;
+  margin: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   max-width: 95%;
+  flex-grow: 1.2;
 
   ${media.mobile`
     white-space: nowrap;
-  `}
+  `};
 `
 
-const Description = styled.p`
-  font-size: 14px;
-  margin: 0;
-  line-height: 18px;
+const Description = styled(ClampLines)`
   text-overflow: ellipsis;
+  font-size: 14px;
+  flex-grow: 2;
+  margin: auto 0;
+  line-height: 18px;
   overflow: hidden;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
 
-  ${({cardSize}) => cardSize !== 'large' && media.mobile`
+  ${({cardSize}) =>
+    cardSize !== 'large' &&
+    media.mobile`
     white-space: nowrap;
-  `}
-
-  ${media.desktop`
-    height: 54px;
-  `}
+  `};
 `
 
 const Url = styled.span`
   font-size: 12px;
-  margin-top: 10px;
+  margin: 0px;
   display: inline-block;
+  flex-grow: 0;
 `
 
-export default ({ title, description, url, cardSize, className }) => (
+export default ({title, description, url, cardSize, className}) => (
   <Content className={className} cardSize={cardSize}>
-    <Title className='microlink_card__content_title' title={title}>{title}</Title>
+    <Title className='microlink_card__content_title' title={title}>
+      {title}
+    </Title>
+
     <Description
+      lines={3}
+      tag='p'
       className='microlink_card__content_description'
+      text={description}
       cardSize={cardSize}
-    >{description}</Description>
+      buttons={false}
+     />
     <Url className='microlink_card__content_url'>{extractDomain(url)}</Url>
   </Content>
 )

--- a/packages/react-microlink/src/components/Card/CardEmptyState.js
+++ b/packages/react-microlink/src/components/Card/CardEmptyState.js
@@ -12,7 +12,7 @@ const EmptyImage = CardImage.extend`
 
 const EmptyTitle = styled.span`
   height: 16px;
-  width: 80%;
+  width: 60%;
   display: block;
   background: #e1e8ed;
   margin: 2px 0 8px;
@@ -21,7 +21,7 @@ const EmptyTitle = styled.span`
 `
 
 const EmptyDescription = styled.span`
-  width: 100%;
+  width: 95%;
   display: block;
   background: #e1e8ed;
   margin-bottom: 12px;
@@ -30,22 +30,16 @@ const EmptyDescription = styled.span`
   ${emptyStateAnimation}
   animation-delay: .125s;
 
-  ${({cardSize}) => cardSize !== 'large' && media.mobile`
-    height: 14px;
-  `}
+  height: 33px;
 
-  ${({cardSize}) => cardSize !== 'large' && media.desktop`
-    height: 54px;
-
-    &:before, &:after {
-      content: '';
-      position: absolute;
-      left: -1px;
-      right: -1px;
-      height: 6px;
-      background: #fff;
-    }
-  `}
+  &:before {
+    content: '';
+    position: absolute;
+    left: -1px;
+    right: -1px;
+    height: 6px;
+    background: #fff;
+  }
 
   &:before {
     top: 14px;
@@ -54,11 +48,15 @@ const EmptyDescription = styled.span`
   &:after {
     bottom: 14px;
   }
+
+  ${({cardSize}) => cardSize !== 'large' && media.mobile`
+    height: 14px;
+  `}
 `
 
 const EmptyLink = styled.span`
   height: 10px;
-  width: 60%;
+  width: 30%;
   display: block;
   background: #e1e8ed;
   opacity: 0.8;

--- a/packages/react-microlink/src/components/Card/CardWrap.js
+++ b/packages/react-microlink/src/components/Card/CardWrap.js
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components'
 import { CardWrapLarge } from './CardLarge'
 
 const style = css`
-  max-width: 558px;
+  max-width: 500px;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   background-color: #fff;
   color: #181919;


### PR DESCRIPTION
before (only on browser with webkit support)

<img width="569" alt="screen shot 2018-01-13 at 22 06 08" src="https://user-images.githubusercontent.com/2096101/34910368-99ee498e-f8b3-11e7-9b83-52e317000784.png">

after (crossbrowser)

<img width="570" alt="screen shot 2018-01-13 at 22 05 58" src="https://user-images.githubusercontent.com/2096101/34910365-963d6054-f8b3-11e7-99c3-3ba4f1dda359.png">

I'm considering use https://github.com/tjindapitak/react-text-ellipsis for that, it supports css and js as fallback solution, I need to check the bundle size implications but could be worth it.