### PR TITLE
Add data property

### DIFF
--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -108,6 +108,9 @@
     "parser": "babel-eslint",
     "plugins": [
       "jsx-a11y"
+    ],
+    "ignore": [
+      "/lib/"
     ]
   }
 }

--- a/packages/react-microlink/src/index.js
+++ b/packages/react-microlink/src/index.js
@@ -5,23 +5,19 @@ import {CardWrap, CardMedia, CardContent, CardEmptyState} from './components/Car
 import {getUrlPath, someProp, createApiUrl} from './utils'
 
 class Microlink extends Component {
-  constructor (props) {
-    super(props)
-    this.setData = this.setData.bind(this)
-  }
-
   componentWillMount () {
     if (this.props.data) return this.setData({data: this.props.data})
-
-    const url = createApiUrl(this.props)
-    this.setState({loading: true})
-
-    return fetch(url, {headers: {'x-api-key': this.props.apiKey}})
-      .then(res => res.json())
-      .then(this.setData)
+    const promise = this.fetchData()
+    return this.setState({loading: true}, () => promise.then(this.setData))
   }
 
-  setData ({data}) {
+  fetchData = () => {
+    const url = createApiUrl(this.props)
+    const promise = fetch(url, {headers: {'x-api-key': this.props.apiKey}})
+    return promise.then(res => res.json())
+  }
+
+  setData = ({data}) => {
     const imagesProps = [].concat(this.props.image)
     const image = someProp(data, imagesProps)
     const imageUrl = getUrlPath(image)

--- a/packages/react-microlink/src/index.js
+++ b/packages/react-microlink/src/index.js
@@ -97,7 +97,7 @@ Microlink.propTypes = {
   apiKey: PropTypes.string,
   contrast: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   image: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-  prerender: PropTypes.bool,
+  prerender: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   screenshot: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   size: PropTypes.oneOf(['normal', 'large']),
   url: PropTypes.string.isRequired,

--- a/packages/react-microlink/src/index.js
+++ b/packages/react-microlink/src/index.js
@@ -104,7 +104,7 @@ Microlink.propTypes = {
   apiKey: PropTypes.string,
   contrast: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   image: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-  prerender: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  prerender: PropTypes.oneOf(['auto', true, false]),
   screenshot: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   size: PropTypes.oneOf(['normal', 'large']),
   url: PropTypes.string.isRequired,

--- a/packages/react-microlink/src/index.js
+++ b/packages/react-microlink/src/index.js
@@ -5,32 +5,39 @@ import {CardWrap, CardMedia, CardContent, CardEmptyState} from './components/Car
 import {getUrlPath, someProp, createApiUrl} from './utils'
 
 class Microlink extends Component {
+  constructor (props) {
+    super(props)
+    this.setData = this.setData.bind(this)
+  }
+
   componentWillMount () {
-    const {image, apiKey} = this.props
-    const imagesProps = [].concat(image)
+    if (this.props.data) return this.setData({data: this.props.data})
+
     const url = createApiUrl(this.props)
+    this.setState({loading: true})
 
-    this.setState({loading: true}, () =>
-      fetch(url, {headers: {'x-api-key': apiKey}})
-        .then(res => res.json())
-        .then(({status, data}) => {
-          const image = someProp(data, imagesProps)
-          const imageUrl = getUrlPath(image)
-          const {title, description, url, video} = data
-          const {color, background_color: backgroundColor} = image || {}
+    return fetch(url, {headers: {'x-api-key': this.props.apiKey}})
+      .then(res => res.json())
+      .then(this.setData)
+  }
 
-          this.setState({
-            color,
-            backgroundColor,
-            title,
-            description,
-            url,
-            loading: false,
-            video,
-            image: imageUrl
-          })
-        })
-    )
+  setData ({data}) {
+    const imagesProps = [].concat(this.props.image)
+    const image = someProp(data, imagesProps)
+    const imageUrl = getUrlPath(image)
+    const {title, description, url, video} = data
+    const {color, background_color: backgroundColor} = image || {}
+
+    this.setState({
+      color,
+      backgroundColor,
+      title,
+      description,
+      url,
+      loading: false,
+      video,
+      image: imageUrl
+    })
   }
 
   renderContent () {

--- a/packages/react-microlink/stories/index.js
+++ b/packages/react-microlink/stories/index.js
@@ -112,6 +112,17 @@ storiesOf('Normal', module)
       )}
     </div>
   ))
+  .add('with custom data', () => (
+    <MicrolinkCard
+      url='https://microlink.io'
+      data={{
+        'title': 'My Custom Title',
+        'image': 'https://microlink.io/logo-trim.png',
+        'description': 'My Custom Description',
+        'url': 'https://microlink.io'
+      }}
+    />
+  ))
   .add('with empty state', () => (
     <MicrolinkCard
       url='somesitethatwontresolve.com'
@@ -233,6 +244,18 @@ storiesOf('Large', module)
         />
       )}
     </div>
+  ))
+  .add('with custom data', () => (
+    <MicrolinkCard
+      url='https://microlink.io'
+      size='large'
+      data={{
+        'title': 'My Custom Title',
+        'image': 'https://microlink.io/logo-trim.png',
+        'description': 'My Custom Description',
+        'url': 'https://microlink.io'
+      }}
+    />
   ))
   .add('with empty state', () => (
     <MicrolinkCard


### PR DESCRIPTION
This PR adds the possibility to load the Card content from a `data` property, instead of fetching the data again.

Useful when you need do a microlink API call and you want to use the data provided as card.

Actually it only add one line more, the rest is refactoring