### PR TITLE
Adjust card text overflow/ellipsis control

### DIFF
--- a/packages/react-microlink/lib/components/Card/CardContent.js
+++ b/packages/react-microlink/lib/components/Card/CardContent.js
@@ -9,10 +9,10 @@ var _jsx = function () { var REACT_ELEMENT_TYPE = typeof Symbol === "function" &
 
 var _templateObject = _taggedTemplateLiteral(['\n  flex: 0 0 125px;\n'], ['\n  flex: 0 0 125px;\n']),
     _templateObject2 = _taggedTemplateLiteral(['\n  display: flex;\n  justify-content: space-around;\n  flex-direction: column;\n  flex: 1;\n  padding: 10px 15px;\n  min-width: 0;\n  box-sizing: border-box;\n  ', ';\n'], ['\n  display: flex;\n  justify-content: space-around;\n  flex-direction: column;\n  flex: 1;\n  padding: 10px 15px;\n  min-width: 0;\n  box-sizing: border-box;\n  ', ';\n']),
-    _templateObject3 = _taggedTemplateLiteral(['\n  font-size: 16px;\n  font-weight: bold;\n  margin: 0;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n  overflow: hidden;\n  max-width: 95%;\n  flex-grow: 1.2;\n\n  ', ';\n'], ['\n  font-size: 16px;\n  font-weight: bold;\n  margin: 0;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n  overflow: hidden;\n  max-width: 95%;\n  flex-grow: 1.2;\n\n  ', ';\n']),
-    _templateObject4 = _taggedTemplateLiteral(['\n    white-space: nowrap;\n  '], ['\n    white-space: nowrap;\n  ']),
-    _templateObject5 = _taggedTemplateLiteral(['\n  text-overflow: ellipsis;\n  font-size: 14px;\n  flex-grow: 2;\n  margin: auto 0;\n  line-height: 18px;\n  overflow: hidden;\n\n  ', ';\n'], ['\n  text-overflow: ellipsis;\n  font-size: 14px;\n  flex-grow: 2;\n  margin: auto 0;\n  line-height: 18px;\n  overflow: hidden;\n\n  ', ';\n']),
-    _templateObject6 = _taggedTemplateLiteral(['\n  font-size: 12px;\n  margin: 0px;\n  display: inline-block;\n  flex-grow: 0;\n'], ['\n  font-size: 12px;\n  margin: 0px;\n  display: inline-block;\n  flex-grow: 0;\n']);
+    _templateObject3 = _taggedTemplateLiteral(['\n  font-size: 16px;\n  font-weight: bold;\n  margin: 0;\n  flex-grow: 1.2;\n'], ['\n  font-size: 16px;\n  font-weight: bold;\n  margin: 0;\n  flex-grow: 1.2;\n']),
+    _templateObject4 = _taggedTemplateLiteral(['\n  font-size: 14px;\n  flex-grow: 2;\n  margin: auto 0;\n  line-height: 18px;\n\n  ', ';\n'], ['\n  font-size: 14px;\n  flex-grow: 2;\n  margin: auto 0;\n  line-height: 18px;\n\n  ', ';\n']),
+    _templateObject5 = _taggedTemplateLiteral(['\n    > div {\n      overflow: hidden;\n      text-overflow: ellipsis;\n      white-space: nowrap;\n    }\n  '], ['\n    > div {\n      overflow: hidden;\n      text-overflow: ellipsis;\n      white-space: nowrap;\n    }\n  ']),
+    _templateObject6 = _taggedTemplateLiteral(['\n  font-size: 12px;\n  margin: 0;\n  flex-grow: 0;\n'], ['\n  font-size: 12px;\n  margin: 0;\n  flex-grow: 0;\n']);
 
 var _react = require('react');
 
@@ -26,13 +26,15 @@ var _extractDomain = require('extract-domain');
 
 var _extractDomain2 = _interopRequireDefault(_extractDomain);
 
-var _reactClampLines = require('react-clamp-lines');
+var _nanoclamp = require('nanoclamp');
 
-var _reactClampLines2 = _interopRequireDefault(_reactClampLines);
+var _nanoclamp2 = _interopRequireDefault(_nanoclamp);
 
 var _utils = require('../../utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
 
@@ -42,40 +44,47 @@ var isLarge = function isLarge(cardSize) {
 
 var largeStyle = (0, _styledComponents.css)(_templateObject);
 
-var Content = exports.Content = _styledComponents2.default.div(_templateObject2, function (_ref) {
-  var cardSize = _ref.cardSize;
+var StyledClamp = function StyledClamp(_ref) {
+  var props = _objectWithoutProperties(_ref, []);
+
+  return _react2.default.createElement(_nanoclamp2.default, props);
+};
+
+var Content = exports.Content = _styledComponents2.default.div(_templateObject2, function (_ref2) {
+  var cardSize = _ref2.cardSize;
   return isLarge(cardSize) && largeStyle;
 });
 
-var Title = _styledComponents2.default.p(_templateObject3, _utils.media.mobile(_templateObject4));
+var Title = (0, _styledComponents2.default)(StyledClamp)(_templateObject3);
 
-var Description = (0, _styledComponents2.default)(_reactClampLines2.default)(_templateObject5, function (_ref2) {
-  var cardSize = _ref2.cardSize;
-  return !isLarge(cardSize) && _utils.media.mobile(_templateObject4);
+var Description = (0, _styledComponents2.default)(StyledClamp)(_templateObject4, function (_ref3) {
+  var cardSize = _ref3.cardSize;
+  return !isLarge(cardSize) && _utils.media.mobile(_templateObject5);
 });
 
-var Url = _styledComponents2.default.span(_templateObject6);
+var Url = (0, _styledComponents2.default)(StyledClamp)(_templateObject6);
 
-exports.default = function (_ref3) {
-  var title = _ref3.title,
-      description = _ref3.description,
-      url = _ref3.url,
-      cardSize = _ref3.cardSize,
-      className = _ref3.className;
+exports.default = function (_ref4) {
+  var title = _ref4.title,
+      description = _ref4.description,
+      url = _ref4.url,
+      cardSize = _ref4.cardSize,
+      className = _ref4.className;
   return _jsx(Content, {
     className: className,
     cardSize: cardSize
   }, void 0, _jsx(Title, {
     className: 'microlink_card__content_title',
-    title: title
-  }, void 0, title), _jsx(Description, {
+    lines: 1,
+    text: title
+  }), _jsx(Description, {
     lines: 2,
-    tag: 'p',
     className: 'microlink_card__content_description',
     text: description,
-    cardSize: cardSize,
-    buttons: false
+    cardSize: cardSize
   }), _jsx(Url, {
-    className: 'microlink_card__content_url'
-  }, void 0, (0, _extractDomain2.default)(url)));
+    lines: 1,
+    className: 'microlink_card__content_url',
+    text: (0, _extractDomain2.default)(url)
+  }));
 };

--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "extract-domain": "~2.0.0",
-    "nanoclamp": "~1.0.1",
+    "nanoclamp": "~1.1.4",
     "styled-components": "~3.1.4"
   },
   "devDependencies": {

--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "extract-domain": "~2.0.0",
-    "react-clamp-lines": "~1.0.2",
+    "nanoclamp": "~1.0.1",
     "styled-components": "~3.1.4"
   },
   "devDependencies": {

--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "extract-domain": "~2.0.0",
-    "nanoclamp": "~1.2.0",
+    "nanoclamp": "~1.2.1",
     "styled-components": "~3.1.4"
   },
   "devDependencies": {

--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "extract-domain": "~2.0.0",
-    "nanoclamp": "~1.1.4",
+    "nanoclamp": "~1.2.0",
     "styled-components": "~3.1.4"
   },
   "devDependencies": {

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -42,7 +42,9 @@ const Description = styled.div`
   flex-grow: 2;
   margin: auto 0;
   line-height: 18px;
-  ${({cardSize}) => !isLarge(cardSize) && media.mobile && mobileDescription};
+  ${({cardSize}) => !isLarge(cardSize) && media.mobile`
+    ${mobileDescription}
+  `};
 `
 
 const Url = styled.footer`

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -38,15 +38,20 @@ const Title = styled.p`
 `
 
 const Description = styled(ClampLines)`
-  text-overflow: ellipsis;
   font-size: 14px;
   flex-grow: 2;
   margin: auto 0;
   line-height: 18px;
-  overflow: hidden;
+
+  > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   ${({cardSize}) => !isLarge(cardSize) && media.mobile`
-    white-space: nowrap;
+    > div {
+      white-space: nowrap;
+    }
   `};
 `
 

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -7,16 +7,18 @@ import {media} from '../../utils'
 
 const isLarge = cardSize => cardSize === 'large'
 
-const largeStyle = css`
+const largeContentStyle = css`
   flex: 0 0 125px;
 `
 
-const mobileDescription = css`
-  > p {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+const mobileDescriptionStyle = css`
+  ${media.mobile`
+    > p {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `}
 `
 
 export const Content = styled.div`
@@ -27,7 +29,7 @@ export const Content = styled.div`
   padding: 10px 15px;
   min-width: 0;
   box-sizing: border-box;
-  ${({cardSize}) => isLarge(cardSize) && largeStyle};
+  ${({cardSize}) => isLarge(cardSize) && largeContentStyle};
 `
 
 const Title = styled.header`
@@ -42,9 +44,7 @@ const Description = styled.div`
   flex-grow: 2;
   margin: auto 0;
   line-height: 18px;
-  ${({cardSize}) => !isLarge(cardSize) && media.mobile`
-    ${mobileDescription}
-  `};
+  ${({cardSize}) => !isLarge(cardSize) && mobileDescriptionStyle};
 `
 
 const Url = styled.footer`
@@ -55,13 +55,13 @@ const Url = styled.footer`
 
 export default ({title, description, url, cardSize, className}) => (
   <Content className={className} cardSize={cardSize}>
-    <Title className="microlink_card__content_title">
+    <Title className='microlink_card__content_title'>
       <CardText lines={1}>{title}</CardText>
     </Title>
-    <Description className="microlink_card__content_description" cardSize={cardSize}>
+    <Description className='microlink_card__content_description' cardSize={cardSize}>
       <CardText lines={2}>{description}</CardText>
     </Description>
-    <Url className="microlink_card__content_url">
+    <Url className='microlink_card__content_url'>
       <CardText lines={1}>{extractDomain(url)}</CardText>
     </Url>
   </Content>

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, {css} from 'styled-components'
 import extractDomain from 'extract-domain'
-import ClampLines from 'react-clamp-lines'
+import NanoClamp from 'nanoclamp'
 
 import {media} from '../../utils'
 
@@ -11,14 +11,7 @@ const largeStyle = css`
   flex: 0 0 125px;
 `
 
-const StyledClamp = ({ className, lines, text }) => (
-  <ClampLines
-    buttons={false}
-    className={className}
-    lines={lines}
-    text={text}
-  />
-)
+const StyledClamp = ({...props}) => <NanoClamp {...props} />
 
 export const Content = styled.div`
   display: flex;

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -70,7 +70,6 @@ export default ({title, description, url, cardSize, className}) => (
 
     <Description
       lines={2}
-      tag='p'
       className='microlink_card__content_description'
       text={description}
       cardSize={cardSize}

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, {css} from 'styled-components'
 import extractDomain from 'extract-domain'
-import NanoClamp from 'nanoclamp'
+import CardText from './CardText'
 
 import {media} from '../../utils'
 
@@ -11,7 +11,13 @@ const largeStyle = css`
   flex: 0 0 125px;
 `
 
-const StyledClamp = ({...props}) => <NanoClamp {...props} />
+const mobileDescription = css`
+  > p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`
 
 export const Content = styled.div`
   display: flex;
@@ -24,29 +30,22 @@ export const Content = styled.div`
   ${({cardSize}) => isLarge(cardSize) && largeStyle};
 `
 
-const Title = styled(StyledClamp)`
+const Title = styled.header`
   font-size: 16px;
   font-weight: bold;
   margin: 0;
   flex-grow: 1.2;
 `
 
-const Description = styled(StyledClamp)`
+const Description = styled.div`
   font-size: 14px;
   flex-grow: 2;
   margin: auto 0;
   line-height: 18px;
-
-  ${({cardSize}) => !isLarge(cardSize) && media.mobile`
-    > div {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-  `};
+  ${({cardSize}) => !isLarge(cardSize) && media.mobile && mobileDescription};
 `
 
-const Url = styled(StyledClamp)`
+const Url = styled.footer`
   font-size: 12px;
   margin: 0;
   flex-grow: 0;
@@ -54,21 +53,14 @@ const Url = styled(StyledClamp)`
 
 export default ({title, description, url, cardSize, className}) => (
   <Content className={className} cardSize={cardSize}>
-    <Title
-      className='microlink_card__content_title'
-      lines={1}
-      text={title}
-    />
-    <Description
-      lines={2}
-      className='microlink_card__content_description'
-      text={description}
-      cardSize={cardSize}
-     />
-    <Url
-      lines={1}
-      className='microlink_card__content_url'
-      text={extractDomain(url)}
-    />
+    <Title className="microlink_card__content_title">
+      <CardText lines={1}>{title}</CardText>
+    </Title>
+    <Description className="microlink_card__content_description" cardSize={cardSize}>
+      <CardText lines={2}>{description}</CardText>
+    </Description>
+    <Url className="microlink_card__content_url">
+      <CardText lines={1}>{extractDomain(url)}</CardText>
+    </Url>
   </Content>
 )

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -11,6 +11,15 @@ const largeStyle = css`
   flex: 0 0 125px;
 `
 
+const StyledClamp = ({ className, lines, text }) => (
+  <ClampLines
+    buttons={false}
+    className={className}
+    lines={lines}
+    text={text}
+  />
+)
+
 export const Content = styled.div`
   display: flex;
   justify-content: space-around;
@@ -22,22 +31,14 @@ export const Content = styled.div`
   ${({cardSize}) => isLarge(cardSize) && largeStyle};
 `
 
-const Title = styled.p`
+const Title = styled(StyledClamp)`
   font-size: 16px;
   font-weight: bold;
   margin: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  max-width: 95%;
   flex-grow: 1.2;
-
-  ${media.mobile`
-    white-space: nowrap;
-  `};
 `
 
-const Description = styled(ClampLines)`
+const Description = styled(StyledClamp)`
   font-size: 14px;
   flex-grow: 2;
   margin: auto 0;
@@ -52,26 +53,29 @@ const Description = styled(ClampLines)`
   `};
 `
 
-const Url = styled.span`
+const Url = styled(StyledClamp)`
   font-size: 12px;
-  margin: 0px;
-  display: inline-block;
+  margin: 0;
   flex-grow: 0;
 `
 
 export default ({title, description, url, cardSize, className}) => (
   <Content className={className} cardSize={cardSize}>
-    <Title className='microlink_card__content_title' title={title}>
-      {title}
-    </Title>
-
+    <Title
+      className='microlink_card__content_title'
+      lines={1}
+      text={title}
+    />
     <Description
       lines={2}
       className='microlink_card__content_description'
       text={description}
       cardSize={cardSize}
-      buttons={false}
      />
-    <Url className='microlink_card__content_url'>{extractDomain(url)}</Url>
+    <Url
+      lines={1}
+      className='microlink_card__content_url'
+      text={extractDomain(url)}
+    />
   </Content>
 )

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -43,13 +43,10 @@ const Description = styled(ClampLines)`
   margin: auto 0;
   line-height: 18px;
 
-  > div {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   ${({cardSize}) => !isLarge(cardSize) && media.mobile`
     > div {
+      overflow: hidden;
+      text-overflow: ellipsis;
       white-space: nowrap;
     }
   `};

--- a/packages/react-microlink/src/components/Card/CardText.js
+++ b/packages/react-microlink/src/components/Card/CardText.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components'
+import NanoClamp from 'nanoclamp'
+
+const Clamp = ({children, className, lines}) => (
+  <NanoClamp className={className} lines={lines} text={children} is="p" />
+)
+
+const CardText = styled(Clamp)`
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: #181919;
+  margin: 0;
+`
+
+export default CardText

--- a/packages/react-microlink/src/components/Card/CardText.js
+++ b/packages/react-microlink/src/components/Card/CardText.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import NanoClamp from 'nanoclamp'
 
 const Clamp = ({children, className, lines}) => (
-  <NanoClamp className={className} lines={lines} text={children} is="p" />
+  <NanoClamp className={className} lines={lines} text={children} is='p' />
 )
 
 const CardText = styled(Clamp)`

--- a/packages/react-microlink/src/components/Card/CardWrap.js
+++ b/packages/react-microlink/src/components/Card/CardWrap.js
@@ -16,9 +16,7 @@ const largeStyle = css`
 
 const style = css`
   max-width: 500px;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   background-color: #fff;
-  color: #181919;
   border-width: 1px;
   border-style: solid;
   border-color: #E1E8ED;


### PR DESCRIPTION
`ClampLines` wraps its content within another `div`, our responsive overflow styles aren't affecting it.

Before:
![image](https://user-images.githubusercontent.com/5795227/36456914-adfcf90e-16a7-11e8-8df1-bf63df839015.png)

After:
![image](https://user-images.githubusercontent.com/5795227/36457033-41da4190-16a8-11e8-86f7-0bd77869fad2.png)
