### PR TITLE
Remove `apiEndpoint` propType

### DIFF
--- a/packages/react-microlink/src/index.js
+++ b/packages/react-microlink/src/index.js
@@ -96,7 +96,6 @@ Microlink.defaultProps = {
 }
 
 Microlink.propTypes = {
-  apiEndpoint: PropTypes.string,
   apiKey: PropTypes.string,
   contrast: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   image: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),


### PR DESCRIPTION
Correct me if I'm mistaken, but I think this propType is deprecated?