### PR TITLE
Move prop-dependent styles to variables

### DIFF
--- a/packages/react-microlink/src/components/Card/CardMedia/image.js
+++ b/packages/react-microlink/src/components/Card/CardMedia/image.js
@@ -3,11 +3,11 @@ import styled, {css} from 'styled-components'
 import { media, isLarge } from '../../../utils'
 
 const largeStyle = css`
-flex: 1;
+  flex: 1;
 
-&::before {
-  padding-bottom: 0;
-}
+  &::before {
+    padding-bottom: 0;
+  }
 `
 
 export default styled.div`

--- a/packages/react-microlink/src/components/Card/CardWrap.js
+++ b/packages/react-microlink/src/components/Card/CardWrap.js
@@ -5,6 +5,17 @@ import { media, isLarge } from '../../utils'
 
 const HEIGHT = '382px'
 
+const contrastStyle = ({backgroundColor, color}) => css`
+  background-color: ${backgroundColor};
+  color: ${color};
+  border-color: ${color};
+  transition: filter .15s ease-in-out;
+
+  &:hover {
+    filter: brightness(90%);
+  }
+`
+
 const largeStyle = css`
   flex-direction: column;
   height: ${HEIGHT};
@@ -12,6 +23,18 @@ const largeStyle = css`
   ${media.mobile`
     height: calc(${HEIGHT} * 7/9);
   `}
+`
+
+const loadingStyle = css`
+  transition: background-color .15s ease-in-out, border-color .15s ease-in-out;
+  &:hover {
+    background: #F5F8FA;
+    border-color: rgba(136,153,166,.5);
+  }
+`
+
+const roundStyle = ({round}) => css`
+  border-radius: ${typeof round === 'boolean' ? `.42857em` : round};
 `
 
 const style = css`
@@ -32,30 +55,13 @@ const style = css`
     outline: 0;
   }
 
-  ${({loading, contrast}) => !loading && !contrast && css`
-    transition: background-color .15s ease-in-out, border-color .15s ease-in-out;
-    &:hover {
-      background: #F5F8FA;
-      border-color: rgba(136,153,166,.5);
-    }
-  `}
+  ${({loading, contrast}) => !loading && !contrast && loadingStyle}
 
-  ${({round}) => round && css`
-    border-radius: ${typeof round === 'boolean' ? `.42857em` : round};
-  `}
+  ${({round}) => round && roundStyle}
 
   ${({cardSize}) => isLarge(cardSize) && largeStyle}
 
-  ${({backgroundColor, color, contrast}) => contrast && color && backgroundColor && css`
-    background-color: ${backgroundColor};
-    color: ${color};
-    border-color: ${color};
-    transition: filter .15s ease-in-out;
-
-    &:hover {
-      filter: brightness(90%);
-    }
-  `}
+  ${({backgroundColor, color, contrast}) => contrast && color && backgroundColor && contrastStyle}
 `
 
 const CardWrap = ({ is, rel, href, target, ...props }) => {


### PR DESCRIPTION
After reading your recent suggestion @Kikobeats (https://github.com/microlinkhq/microlinkjs/pull/72#pullrequestreview-98148844), I see it better-structured this way. So I've moved some of the other style blocks to follow suit.