### PR TITLE
Fix `clean` package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:packages": "lerna run build",
     "changelog": "conventional-changelog --release-count=0 > CHANGELOG.md",
     "changelog:commit": "npm run changelog && git add CHANGELOG.md && git commit -m 'Update Changelog' && git push origin master",
-    "clean": "rm -rf node_modules && cd packages && eachdir rm -rf node_modules",
+    "clean": "cd packages && eachdir rm -rf node_modules && cd .. && rm -rf node_modules",
     "dev": "concurrently 'gulp' 'npm run browser-sync'",
     "lint": "standard-markdown && standard src",
     "postinstall": "lerna bootstrap && lerna link --force-local",


### PR DESCRIPTION
+ Adjust order of clean’s commands, currently it only works if `eachdir` is globally installed (because it gets removed in the first step)